### PR TITLE
Path construction and Python 3

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -8,25 +8,27 @@ maindir = "/home/user/photos-upload/" #where the photos and count file will be, 
 offsiteloc = "url.org:/var/www/photos/" #the server to send to include exact path "myserver.com:/var/www/photos/"
 #------------------------------------------------------------------------
 
-if len(maindir) != 0:
-	if maindir[-1] != "/":
-		maindir = maindir + "/"
+olddir = os.path.join(maindir, "old")
 
-if len(offsiteloc) != 0:
-	if offsiteloc[-1] != "/":
-		offsiteloc = offsiteloc + "/"
+logger = logging.getLogger("upload")
+logger.setLevel(logging.INFO)
 
-if os.path.exists(maindir + "count.txt") == False:
-	with open(maindir + "count.txt","w") as handle:
+if not maindir or not offsiteloc:
+	raise RuntimeException("Ensure you have set the maindir and offsiteloc "
+			       "configuration variables.")
+
+if os.path.exists(os.path.join(maindir, "count.txt")) == False:
+	# Initialise the counter
+	with open(os.path.join(maindir, "count.txt"), "w") as handle:
 		handle.write("0")
 
-if os.path.exists(maindir + "old/") == False:
-	os.system("mkdir " + maindir + "old/")
+if os.path.exists(olddir) == False:
+	os.system("mkdir " + olddir)
 
-with open(maindir + "count.txt","r") as handle:
+with open(os.path.join(maindir, "count.txt"), "r") as handle:
 	count = int(handle.read())
 
-files = glob.glob(maindir + "*")
+files = glob.glob(os.path.join(maindir, "*"))
 
 photos = []
 for x in files:

--- a/upload.py
+++ b/upload.py
@@ -1,6 +1,7 @@
 #send photos to gallery server
 
 import glob
+import logging
 import os
 
 #------------------------------------------------------------------------
@@ -37,7 +38,7 @@ for x in files:
 			photos.append(x)
 
 if len(photos) == 0:
-	print "Could not find any photos"
+	logger.error("Could not find any photos")
 else:
 	for x in photos:
 		os.system("mogrify -auto-orient -resize 640 " + x)
@@ -48,4 +49,4 @@ else:
 		handle.write(str(count))
 	os.system("rsync -ave ssh " + maindir + "*.jpg " + offsiteloc)
 	os.system("mv " + maindir + "*.jpg " + maindir + "old/")
-	print "Finished Uploading images."
+	logger.info("Finished Uploading images.")


### PR DESCRIPTION
* Use os.path.join for path construction to be more forgiving on trailing slashes and also lay groundwork for better cross-platform support
* Use logging, not print, with a side effect that Python 3 won't complain about missing parens on prints anymore